### PR TITLE
Try to build with perl

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -3,8 +3,6 @@ name: test-go
 on:
   push:
   pull_request:
-    types:
-      - merged
     branches:
       - main
 

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -3,8 +3,6 @@ name: test-java
 on:
   push:
   pull_request:
-    types:
-      - merged
     branches:
       - main
 

--- a/.github/workflows/test-javascript.yml
+++ b/.github/workflows/test-javascript.yml
@@ -3,8 +3,6 @@ name: test-javascript
 on:
   push:
   pull_request:
-    types:
-      - merged
     branches:
       - main
 

--- a/.github/workflows/test-perl.yml
+++ b/.github/workflows/test-perl.yml
@@ -1,0 +1,35 @@
+name: test-perl
+
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        perl: [ "5.32" ]
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v2
+
+    - name: Setup Perl environment
+      uses: shogo82148/actions-setup-perl@v1
+      with:
+        perl-version: ${{ matrix.perl }}
+        working-directory: perl
+
+    - name: Run tests
+      run: cd perl && make test
+
+    # Run author tests second so as to not 'contaminate' the environment
+    # with dependencies listed as author deps when they should have been
+    # listed as general deps
+    - name: Run author tests
+      run: cd perl && make authortest
+
+

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -3,8 +3,6 @@ name: test-ruby
 on:
   push:
   pull_request:
-    types:
-      - merged
     branches:
       - main
 

--- a/perl/Makefile
+++ b/perl/Makefile
@@ -1,16 +1,13 @@
 include default.mk
 
-PERL5LIB  = $$PWD/perl5/lib/perl5
-PERL5PATH = $$PWD/perl5/bin
-
-
-
 test: .cpanfile_dependencies
-	PERL5LIB=${PERL5LIB} AUTHOR_TESTS=1 prove -l
-.PHONY: test clean clobber
+	AUTHOR_TESTS=1 prove -l
+.PHONY: test
+
+authortest: .cpanfile_dev_dependencies
+	AUTHOR_TESTS=1 prove -l
+.PHONY: authortest
 
 clean:
 	rm -rf Cucumber-* .cpanfile_dependencies .built CHANGELOG.md
-
-clobber: clean
-# empty target
+.PHONY: clean

--- a/perl/default.mk
+++ b/perl/default.mk
@@ -5,17 +5,6 @@
 SHELL := /usr/bin/env bash
 ALPINE := $(shell which apk 2> /dev/null)
 
-### COMMON stuff for all platforms
-
-BERP_VERSION = 1.3.0
-BERP_GRAMMAR = gherkin.berp
-
-define berp-generate-parser =
--! dotnet tool list --tool-path /usr/bin | grep "berp\s*$(BERP_VERSION)" && dotnet tool update Berp --version $(BERP_VERSION) --tool-path /usr/bin
-berp -g $(BERP_GRAMMAR) -t $< -o $@ --noBOM
-endef
-
-
 ### Common targets for all functionalities implemented on Perl
 
 default: test
@@ -43,7 +32,11 @@ endif
 .PHONY: update-version
 
 .cpanfile_dependencies: cpanfile
-	PERL5LIB=${PERL5LIB} cpanm --notest --local-lib ./perl5 --installdeps .
+	cpanm --with-test --notest --installdeps .
+	touch $@
+
+.cpanfile_dev_dependencies: cpanfile
+	cpanm --with-devel --notest --installdeps .
 	touch $@
 
 predistribution: dist-clean test CHANGELOG.md


### PR DESCRIPTION
@aslakhellesoy , @aurelien-reeves 

Please find here the PR you need to make `tag-expressions` build with Perl. There's one thing with this setup: You originally built with Perl 5.14. I found a bug in the test suite and one in the dependency listing when running with somewhat older Perls. I'll PR those, but only once we have the infrastructure running, so we can have the infrastructure change separated from actual code changes.