### PR TITLE
Illegal escape detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* Only allow escape character (\) in front of (, ), or \. Throw error otherwise. ([#17](https://github.com/cucumber/tag-expressions/pull/17))
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
 
+* Document escaping. ([#16](https://github.com/cucumber/tag-expressions/issues/16), [#17](https://github.com/cucumber/tag-expressions/pull/17))
 * [Ruby] Empty expression evaluates to true
 
 ## [4.1.0] - 2021-10-08

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ For more complex Tag Expressions you can use parenthesis for clarity, or to chan
 
     (@smoke or @ui) and (not @slow)
 
+## Escaping
+
+If you need to use one of the reserved characters `(`, `)`, `\` or ` ` (whitespace) in a tag,
+you can escape it with a `\`. Examples:
+
+| Gherkin Tag   | Escaped Tag Expression |
+| ------------- | ---------------------- |
+| @x(y)         | @x\(y\)                |
+| @x\y          | @x\\y                  |
+
 ## Migrating from old style tags
 
 Older versions of Cucumber used a different syntax for tags. The list below

--- a/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
+++ b/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
@@ -91,7 +91,6 @@ public final class TagExpressionParser {
 
     private static List<String> tokenize(String expr) {
         List<String> tokens = new ArrayList<>();
-
         boolean isEscaped = false;
         StringBuilder token = new StringBuilder();
         for (int i = 0; i < expr.length(); i++) {
@@ -103,31 +102,21 @@ public final class TagExpressionParser {
                 } else {
                     throw new TagExpressionException("Tag expression \"%s\" could not be parsed because of syntax error: Illegal escape before \"%s\".", expr, c);
                 }
-            } else {
-                isEscaped = c == ESCAPING_CHAR;
-                if (Character.isWhitespace(c)) { // skip
-                    if (token.length() > 0) { // end of token
-                        tokens.add(token.toString());
-                        token = new StringBuilder();
-                    }
-                } else if(!isEscaped) {
-                    switch (c) {
-                        case '(':
-                        case ')':
-                            if (token.length() > 0) { // end of token
-                                tokens.add(token.toString());
-                                token = new StringBuilder();
-                            }
-                            tokens.add(String.valueOf(c));
-                            break;
-                        default:
-                            token.append(c);
-                            break;
-                    }
+            } else if (c == ESCAPING_CHAR) {
+                isEscaped = true;
+            } else if (c == '(' || c == ')' || Character.isWhitespace(c)) {
+                if (token.length() > 0) {
+                    tokens.add(token.toString());
+                    token = new StringBuilder();
                 }
+                if (!Character.isWhitespace(c)) {
+                    tokens.add(String.valueOf(c));
+                }
+            } else {
+                token.append(c);
             }
         }
-        if (token.length() > 0) { // end of token
+        if (token.length() > 0) {
             tokens.add(token.toString());
         }
         return tokens;

--- a/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
+++ b/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
@@ -189,15 +189,11 @@ public final class TagExpressionParser {
 
         @Override
         public String toString() {
-            String v1 = value
-                    .replaceAll(Pattern.quote("\\"), Matcher.quoteReplacement("\\\\"));
-            String v2 = v1
-                    .replaceAll(Pattern.quote("("), Matcher.quoteReplacement("\\("));
-            String v3 = v2
-                    .replaceAll(Pattern.quote(")"), Matcher.quoteReplacement("\\)"));
-            String v4 = v3
+            return value
+                    .replaceAll(Pattern.quote("\\"), Matcher.quoteReplacement("\\\\"))
+                    .replaceAll(Pattern.quote("("), Matcher.quoteReplacement("\\("))
+                    .replaceAll(Pattern.quote(")"), Matcher.quoteReplacement("\\)"))
                     .replaceAll("\\s", "\\\\ ");
-            return v4;
         }
     }
 

--- a/javascript/src/index.ts
+++ b/javascript/src/index.ts
@@ -55,7 +55,7 @@ export default function parse(infix: string): Node {
         pushExpr(pop(operators), expressions)
       }
       if (operators.length === 0) {
-        throw Error(
+        throw new Error(
           `Tag expression "${infix}" could not be parsed because of syntax error: Unmatched ).`
         )
       }
@@ -72,7 +72,7 @@ export default function parse(infix: string): Node {
 
   while (operators.length > 0) {
     if (peek(operators) === '(') {
-      throw Error(
+      throw new Error(
         `Tag expression "${infix}" could not be parsed because of syntax error: Unmatched (.`
       )
     }
@@ -93,36 +93,33 @@ export default function parse(infix: string): Node {
 function tokenize(expr: string): string[] {
   const tokens = []
   let isEscaped = false
-  let token: string[] | undefined
+  let token: string[] = []
   for (let i = 0; i < expr.length; i++) {
     const c = expr.charAt(i)
-    if ('\\' === c && !isEscaped) {
-      isEscaped = true
-    } else {
-      if (/\s/.test(c)) {
-        // skip
-        if (token) {
-          // end of token
-          tokens.push(token.join(''))
-          token = undefined
-        }
-      } else {
-        if ((c === '(' || c === ')') && !isEscaped) {
-          if (token) {
-            // end of token
-            tokens.push(token.join(''))
-            token = undefined
-          }
-          tokens.push(c)
-          continue
-        }
-        token = token ? token : [] // start of token
+    if (isEscaped) {
+      if (c === '(' || c === ')' || c === '\\' || /\s/.test(c)) {
         token.push(c)
+        isEscaped = false
+      } else {
+        throw new Error(
+          `Tag expression "${expr}" could not be parsed because of syntax error: Illegal escape before "${c}".`
+        )
       }
-      isEscaped = false
+    } else if (c === '\\') {
+      isEscaped = true
+    } else if (c === '(' || c === ')' || /\s/.test(c)) {
+      if (token.length > 0) {
+        tokens.push(token.join(''))
+        token = []
+      }
+      if (!/\s/.test(c)) {
+        tokens.push(c)
+      }
+    } else {
+      token.push(c)
     }
   }
-  if (token) {
+  if (token.length > 0) {
     tokens.push(token.join(''))
   }
   return tokens
@@ -177,7 +174,11 @@ class Literal implements Node {
   }
 
   public toString() {
-    return this.value.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)')
+    return this.value
+      .replace(/\\/g, '\\\\')
+      .replace(/\(/g, '\\(')
+      .replace(/\)/g, '\\)')
+      .replace(/\s/g, '\\ ')
   }
 }
 

--- a/ruby/lib/cucumber/tag_expressions/expressions.rb
+++ b/ruby/lib/cucumber/tag_expressions/expressions.rb
@@ -11,7 +11,11 @@ module Cucumber
       end
 
       def to_s
-        @value.gsub(/\\/, "\\\\\\\\").gsub(/\(/, "\\(").gsub(/\)/, "\\)")
+        @value
+          .gsub(/\\/, "\\\\\\\\")
+          .gsub(/\(/, "\\(")
+          .gsub(/\)/, "\\)")
+          .gsub(/\s/, "\\ ")
       end
     end
 

--- a/ruby/lib/cucumber/tag_expressions/parser.rb
+++ b/ruby/lib/cucumber/tag_expressions/parser.rb
@@ -65,36 +65,35 @@ module Cucumber
       end
 
       def tokenize(infix_expression)
+        tokens = []
         escaped = false
         token = ""
-        result = []
         infix_expression.chars.each do | ch |
-          if ch == '\\' && !escaped
-            escaped = true
-          else
-            if ch.match(/\s/)
-              if token.length > 0
-                result.push(token)
-                token = ""
-              end
+          if escaped
+            if ch == '(' || ch == ')' || ch == '\\' || ch.match(/\s/)
+              token += ch
+              escaped = false
             else
-              if (ch == '(' || ch == ')') && !escaped
-                if token.length > 0
-                  result.push(token)
-                  token = ""
-                end
-                result.push(ch)
-              else
-                token = token + ch
-              end
+              raise %Q{Tag expression "#{infix_expression}" could not be parsed because of syntax error: Illegal escape before "#{ch}".}
             end
-            escaped = false
+          elsif ch == '\\'
+            escaped = true
+          elsif ch == '(' || ch == ')' || ch.match(/\s/)
+            if token.length > 0
+              tokens.push(token)
+              token = ""
+            end
+            if !ch.match(/\s/)
+              tokens.push(ch)
+            end
+          else
+            token += ch
           end
         end
         if token.length > 0
-          result.push(token)
+          tokens.push(token)
         end
-        result
+        tokens
       end
 
       def push_expression(token)

--- a/testdata/errors.yml
+++ b/testdata/errors.yml
@@ -14,3 +14,7 @@
   error: 'Tag expression "( a and b ) )" could not be parsed because of syntax error: Unmatched ).'
 - expression: '( ( a and b )'
   error: 'Tag expression "( ( a and b )" could not be parsed because of syntax error: Unmatched (.'
+- expression: 'x or \y or z'
+  error: 'Tag expression "x or \y or z" could not be parsed because of syntax error: Illegal escape before "y".'
+- expression: 'x\ or y'
+  error: 'Tag expression "x\ or y" could not be parsed because of syntax error: Expected operator.'

--- a/testdata/evaluations.yml
+++ b/testdata/evaluations.yml
@@ -23,13 +23,13 @@
       result: true
     - variables: ['y']
       result: true
-- expression: 'x\(1\) or(y\(2\))'
+- expression: 'x\(1\) or y\(2\)'
   tests:
     - variables: ['x(1)']
       result: true
     - variables: ['y(2)']
       result: true
-- expression: 'x\\ or(y\\\)) or(z\\)'
+- expression: 'x\\ or y\\\) or z\\'
   tests:
     - variables: ['x\']
       result: true
@@ -43,17 +43,17 @@
       result: false
     - variables: ['z']
       result: false
-- expression: '\x or y\ or z\'
+- expression: '\\x or y\\ or z\\'
   tests:
-    - variables: ['x']
-      result: true
-    - variables: ['y']
-      result: true
-    - variables: ['z']
-      result: true
     - variables: ['\x']
+      result: true
+    - variables: ['y\']
+      result: true
+    - variables: ['z\']
+      result: true
+    - variables: ['x']
       result: false
-    - variables: ['\y']
+    - variables: ['y']
       result: false
-    - variables: ['\z']
+    - variables: ['z']
       result: false

--- a/testdata/parsing.yml
+++ b/testdata/parsing.yml
@@ -28,11 +28,11 @@
   formatted: '( a and \\b )'
 - expression: 'x or(y) '
   formatted: '( x or y )'
-# Operands with escaped parenthesis
 - expression: 'x\(1\) or(y\(2\))'
   formatted: '( x\(1\) or y\(2\) )'
 - expression: '\\x or y\\ or z\\'
   formatted: '( ( \\x or y\\ ) or z\\ )'
-# Operands with escaped backslash
 - expression: 'x\\ or(y\\\)) or(z\\)'
   formatted: '( ( x\\ or y\\\) ) or z\\ )'
+- expression: 'x\  or y'
+  formatted: '( x\  or y )'


### PR DESCRIPTION
# Description

Only allow escape character (`\`) in front of `(`, `)`, ` ` or `\`. Throw error otherwise.

# Motivation & context

It makes the grammar less ambiguous.

## Type of change

- Breaking change (will cause existing functionality to not
  work as expected)

## Update required of cucumber.io/docs

- [x] I have read the [**CONTRIBUTING**](../CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] I have added tests to cover my changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
