### PR TITLE
FIX: CI problems in Python tests

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -1,4 +1,7 @@
 name: test-python
+defaults:
+  run:
+    working-directory: python
 
 on:
   push:
@@ -14,7 +17,8 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        python-version: [ '2.x', '3.x', 'pypy-2.7', 'pypy-3.6', 'pypy-3.7' ]
+        python-version: [ '3.x', '2.x', 'pypy-3.8', 'pypy-2.7' ]
+        # DISABLED: python-version: [ '3.x', '2.x' ]
         # include:
         #   - os: macos-latest
         #     python-version: '3.x'
@@ -26,6 +30,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
-    - name: test
-      working-directory: python
-      run: make test
+    - name: Show Python version
+      run: python --version
+    - name: Install Python package dependencies
+      run: |
+        python -m pip install -U pip setuptools wheel
+        pip install -U -r py.requirements/ci.github.testing.txt
+        pip install -e .
+    - name: Run tests
+      run: pytest

--- a/python/py.requirements/ci.github.testing.txt
+++ b/python/py.requirements/ci.github.testing.txt
@@ -1,0 +1,2 @@
+-r basic.txt
+-r testing.txt


### PR DESCRIPTION
### 🤔 What's changed?

* Use commands directly instead of using the makefile
* Avoid to use `pipenv` (to avoid such problems in the future; this is at least the second time)

OTHERWISE:

* Optimize CI jobs run order (more important Python versions first: `py3.x` before `py2.x`)
* `pypy` versions: Switched to slightly newer Python versions.

MISSING:

* Adapt makefile accordingly to remove usage of pipenv. 
  This change will be performed in another pull-request.

### ⚡️ What's your motivation? 

Fix the CI build problem when running test in Python.
It seems that it is better to avoid to use `pipenv`.
Therefore, it is removed now in the CI pipeline (where it is actually not needed).

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
