### PR TITLE
PYTHON: Fix tox configuration for Python 2.7

### DIFF
--- a/python/tox.ini
+++ b/python/tox.ini
@@ -22,8 +22,8 @@
 
 [tox]
 minversion   = 2.8
-envlist      = py310, py39, pypy3
-skip_missing_interpreters = True
+envlist      = py310, py27, py39, pypy3
+skip_missing_interpreters = true
 
 
 # -----------------------------------------------------------------------------
@@ -39,19 +39,12 @@ passenv =
      PYTHONPATH = {toxinidir}
 
 
-# -- SPECIAL CASE: pytest script does not seem to be installed.
+# -- SPECIAL CASE:Script(s) do not seem to be installed.
+# RELATED: https://github.com/pypa/virtualenv/issues/2284 -- macOS 12 Monterey related
 # NOTES:
-#  * Python 2.7 seems to be broken in tox (due to: pip)
-#    THEREFORE: Remove from "envlist" above for now.
-#  * I can still run tests in own virtual-environment.
-#
-# VIRTUAL-ENVIRONMENT SETUP PROCEDURE:
-#   virtualenv -p python2.7 .venv_py27
-#   source .venv_py27
-#   scripts/ensurepip_python27.sh
-#   python -mpip install -r py.requirements/basic.txt
-#   python -mpip install -r py.requirements/testing.txt
+#  * pip-install seems to need "--user" option.
 [testenv:py27]
+install_command = pip install --user -U {opts} {packages}
 changedir = {toxinidir}
 commands=
     python -mpytest {posargs:tests}
@@ -60,6 +53,13 @@ deps=
 passenv =
      PYTHONPATH = {toxinidir}
 # MAYBE: allowlist_externals = curl
+
+# -- VIRTUAL-ENVIRONMENT SETUP PROCEDURE: For python 2.7
+#   virtualenv -p python2.7 .venv_py27
+#   source .venv_py27
+#   scripts/ensurepip_python27.sh
+#   python -mpip install -r py.requirements/basic.txt
+#   python -mpip install -r py.requirements/testing.txt
 
 
 [testenv:devenv]


### PR DESCRIPTION
### 🤔 What's changed?

* Fixes a problem in DEVELOPMENT support when using `tox` for Python 2.7.
* Problem seems to be related to macOS 12 Monterey
  SEE: https://github.com/pypa/virtualenv/issues/2284
* Use special section in "tox.ini" and
  use "pip install --user ..." to fix the problem for now.
* Added "py27" to `envlist` config parameter again (now that it is usable again).

### ⚡️ What's your motivation? 

Fix a problem for using `tox -e py27` for running test in an isolated virtual-environment for Python 2.7.
This case was disabled during the latest when it was discovered.
The problem is fixed for now (until the real problem is fixed).

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

No.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
