### PR TITLE
Handling error response when a comma is present in the operand name of tags

### DIFF
--- a/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
+++ b/java/src/main/java/io/cucumber/tagexpressions/TagExpressionParser.java
@@ -10,6 +10,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public final class TagExpressionParser {
+    //regex for operands to ensure no oprerand has ',' in them later can be customized further
+    private final static String VALID_OPERAND = "^[^,]*$";
     private static final Map<String, Assoc> ASSOC = new HashMap<String, Assoc>() {{
         put("or", Assoc.LEFT);
         put("and", Assoc.LEFT);
@@ -106,6 +108,7 @@ public final class TagExpressionParser {
                 isEscaped = true;
             } else if (c == '(' || c == ')' || Character.isWhitespace(c)) {
                 if (token.length() > 0) {
+                    isOperandValid(token,expr);
                     tokens.add(token.toString());
                     token = new StringBuilder();
                 }
@@ -116,10 +119,25 @@ public final class TagExpressionParser {
                 token.append(c);
             }
         }
-        if (token.length() > 0) {
+        isOperandValid(token,expr);
+        if (token.length() > 0)  {
             tokens.add(token.toString());
         }
         return tokens;
+    }
+
+    /**
+     * this method checks if the operand comply with the req
+     * regex if not throws exception
+     * @param token supposed tag of token
+     * @param expr entire expression
+     */
+    private static void isOperandValid(StringBuilder token,String expr){
+        if(!String.valueOf(token).matches(VALID_OPERAND)){
+            throw new TagExpressionException("Tag expression \"%s\" could not be parsed because of syntax error: Tag names should follow this pattern \"%s\"",
+             expr, VALID_OPERAND);
+        }
+
     }
 
     private void check(TokenType expectedTokenType, TokenType tokenType) {


### PR DESCRIPTION
<!---
Thanks for helping to make Cucumber better! 💖

You can feel free to open a "Draft" status pull request if you're not ready for feedback yet.

Don't worry about getting everything perfect! We're here to help and will coach you through
to getting your pull request ready to merge.

The prompts below are for guidance to help you describe your change in a way that is most 
likely to make sense to other people when they are reviewing it. Still, it's just a guide, 
so feel free to delete anything that doesn't feel appropriate, and add anything additional 
that seems like it would provide useful context. 👏🏻
-->

### 🤔 What's changed?
to handle tags cases like @step1,@step2

adding regex to handle cases if the operand name of tags contains commas, in future this regex can be further extended
to handle any new case that will arise


### ⚡️ What's your motivation? 
heavily use this library, and wanted to contribute.
### 🏷️ What kind of change is this?
I came across issue [issue](https://github.com/cucumber/cucumber-jvm/issues/2776). Although the documentation specifies the expected format for tags, it seems that the pattern used by the user, '@step1,@step2,' did not generate any error. This discrepancy has the potential to confuse users. To address this, it would be beneficial to implement a validation mechanism that throws an appropriate error when such patterns are encountered.

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)
- :zap: New feature (non-breaking change which adds new behaviour)
- :boom: Breaking change (incompatible changes to the API)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

added support for regex filtering on operand names of tags
Limitations
1)Currently only handling case ',' in operand name
2)Currently just modified the java module of this lib

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
