### PR TITLE
Stop testing long-deprecated python-2.7

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        python-version: [ "3.x", "pypy-3.10", "pypy-2.7" ]
+        python-version: [ "3.x", "pypy-3.10" ]
         # DISABLED: python-version: [ '3.x', '2.x' ]
         # include:
         #   - os: macos-latest


### PR DESCRIPTION
### 🤔 What's changed?

pypy-2.7 removed from python test matrix

### ⚡️ What's your motivation? 

The tests have been failing for some time now *and* Python 2.7 itself has been deprecated  for I-don't-know-how-long...

### 🏷️ What kind of change is this?

:bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

Agree that Python 2.7 really is past its point of no return.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
