### PR TITLE
Build go with v1.20 and v1.21

### DIFF
--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -17,12 +17,12 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        go-version: ['1.13.x', '1.18.x']
+        go-version: ['1.20.x', '1.21.x']
         include:
           - os: windows-latest
-            go-version: '1.18.x'
+            go-version: '1.21.x'
           - os: macos-latest
-            go-version: '1.18.x'
+            go-version: '1.21.x'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
The older versions have reach their EOL
