### PR TITLE
Don't run test-data based tests out-of-tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- [Perl] Fixed test failures when running tests out-of-tree by
+resticting testdata based tests to run in development only
+(by [ehuelsmann](https://github.com/ehuelsmann))
 
 ## [5.0.5] - 2023-08-11
 ### Fixed

--- a/perl/Makefile
+++ b/perl/Makefile
@@ -1,11 +1,11 @@
 include default.mk
 
 test: .cpanfile_dependencies
-	AUTHOR_TESTS=1 prove -l
+	AUTHOR_TESTING=1 prove -l
 .PHONY: test
 
 authortest: .cpanfile_dev_dependencies
-	AUTHOR_TESTS=1 prove -l
+	AUTHOR_TESTING=1 prove -l
 .PHONY: authortest
 
 clean:

--- a/perl/t/03-shared-tests.t
+++ b/perl/t/03-shared-tests.t
@@ -11,6 +11,8 @@ use YAML qw(LoadFile);
 
 use Cucumber::TagExpressions;
 
+plan skip_all => 'AUTHOR_TESTING not enabled'
+   if not $ENV{AUTHOR_TESTING};
 
 my $cases = LoadFile('../testdata/evaluations.yml');
 


### PR DESCRIPTION
### 🤔 What's changed?

Part of the test suite is skipped when the environment variable "AUTHOR_TESTING" isn't set.

### ⚡️ What's your motivation? 

The tests based on the test data fail everywhere, except in our repository, because the test data isn't distributed. Fixing this is important, because Perl insists on running tests whenever it installs software on a system. Which - without this fix - fails everywhere.

### 🏷️ What kind of change is this?

:bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

