### PR TITLE
[Perl] Include LICENSE and README.md in the release tarball

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- [Perl] Include README.md and LICENSE in the release tarball
+(by [ehuelsmann](https://github.com/ehuelsmann))
 
 ## [5.0.6] - 2023-08-13
 ### Fixed

--- a/perl/dist.ini
+++ b/perl/dist.ini
@@ -37,6 +37,8 @@ exclude_filename=VERSION
 ; explicitly add unversioned files
 root=../
 filename=CHANGELOG.md
+filename=LICENSE
+filename=README.md
 
 [Hook::VersionProvider]
 . = my $v = `cat ./VERSION`; chomp( $v ); $v;


### PR DESCRIPTION
### 🤔 What's changed?

The LICENSE and README.md from the repository root will now be included in the perl release tarball.

### ⚡️ What's your motivation? 

Perl tarballs are expected to have these files, as reported by Kwalitee (https://cpants.cpanauthors.org/release/CUKEBOT/Cucumber-TagExpressions-5.0.6)

### 🏷️ What kind of change is this?

:bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?


### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
