### PR TITLE
[Python] Handle escape also in Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- [Python] Support the feature of escaping also in Python ([#144](https://github.com/cucumber/tag-expressions/pull/144))
+
 ### Fixed
 - [Ruby] Fixed up around 75% of all rubocop offenses ([#138](https://github.com/cucumber/tag-expressions/pull/138))
 

--- a/python/cucumber_tag_expressions/__init__.py
+++ b/python/cucumber_tag_expressions/__init__.py
@@ -8,8 +8,10 @@ Theses selected items are normally included in a test run.
 
 .. see also:: https://cucumber.io/docs/cucumber/api/#tag-expressions
 
+    # pylint: disable=line-too-long
 .. _`cucumber tag-expressions`: https://cucumber.io/docs/cucumber/api/#tag-expressions
 .. _`Gherkin`: https://cucumber.io/docs/gherkin/reference/
+    # pylint: disable=line-too-long
 .. _`behave: Gherkin`: https://behave.readthedocs.io/en/latest/philosophy.html#the-gherkin-language
 """
 

--- a/python/cucumber_tag_expressions/model.py
+++ b/python/cucumber_tag_expressions/model.py
@@ -30,6 +30,8 @@ Provides model classes to evaluate parsed boolean tag expressions.
     assert False == expression.evaluate([])
 """
 
+import re
+
 
 # -----------------------------------------------------------------------------
 # TAG-EXPRESSION MODEL CLASSES:
@@ -60,7 +62,9 @@ class Literal(Expression):
         return bool(truth_value)
 
     def __str__(self):
-        return self.name
+        return re.sub(r'(\s)', r'\\\1',
+                      self.name.replace('\\', '\\\\').
+                      replace('(', '\\(').replace(')', '\\)'))
 
     def __repr__(self):
         return "Literal('%s')" % self.name

--- a/python/cucumber_tag_expressions/parser.py
+++ b/python/cucumber_tag_expressions/parser.py
@@ -57,6 +57,7 @@ class Token(Enum):
     OPEN_PARENTHESIS  = ("(", -2) # Java, Javascript: -2, Ruby: 1
     CLOSE_PARENTHESIS = (")", -1)
 
+    # pylint: disable=line-too-long
     def __init__(self, keyword, precedence, assoc=None, token_type=TokenType.OPERAND):
         self.keyword = keyword
         self.precedence = precedence
@@ -147,6 +148,7 @@ class TagExpressionParser(object):
         * `Shunting Yard algorithm`_
         * http://rosettacode.org/wiki/Parsing/Shunting-yard_algorithm
 
+    # pylint: disable=line-too-long
     .. _`Shunting Yard algorithm`: https://en.wikipedia.org/wiki/Shunting-yard_algorithm
     """
     # pylint: disable=too-few-public-methods
@@ -217,7 +219,7 @@ class TagExpressionParser(object):
             #  -- CASE: Empty tag-expression is always true.
             return True_()
 
-        def ensure_expected_token_type(token_type):
+        def ensure_expected_token_type(token_type, index):
             if expected_token_type != token_type:
                 message = "Syntax error. Expected %s after %s" % \
                           (expected_token_type.name.lower(), last_part)
@@ -233,15 +235,15 @@ class TagExpressionParser(object):
             token = cls.select_token(part)
             if token is None:
                 # -- CASE OPERAND: Literal or ...
-                ensure_expected_token_type(TokenType.OPERAND)
+                ensure_expected_token_type(TokenType.OPERAND, index)
                 expressions.append(cls.make_operand(part))
                 expected_token_type = TokenType.OPERATOR
             elif token.is_unary:
-                ensure_expected_token_type(TokenType.OPERAND)
+                ensure_expected_token_type(TokenType.OPERAND, index)
                 operations.append(token)
                 expected_token_type = TokenType.OPERAND
             elif token.is_operation:
-                ensure_expected_token_type(TokenType.OPERATOR)
+                ensure_expected_token_type(TokenType.OPERATOR, index)
                 while (operations and operations[-1].is_operation and
                        token.has_lower_precedence_than(operations[-1])):
                     last_operation = operations.pop()
@@ -249,11 +251,11 @@ class TagExpressionParser(object):
                 operations.append(token)
                 expected_token_type = TokenType.OPERAND
             elif token is Token.OPEN_PARENTHESIS:
-                ensure_expected_token_type(TokenType.OPERAND)
+                ensure_expected_token_type(TokenType.OPERAND, index)
                 operations.append(token)
                 expected_token_type = TokenType.OPERAND
             elif token is Token.CLOSE_PARENTHESIS:
-                ensure_expected_token_type(TokenType.OPERATOR)
+                ensure_expected_token_type(TokenType.OPERATOR, index)
                 while operations and operations[-1] != Token.OPEN_PARENTHESIS:
                     last_operation = operations.pop()
                     cls._push_expression(last_operation, expressions)

--- a/python/tests/data/test_errors.py
+++ b/python/tests/data/test_errors.py
@@ -42,9 +42,6 @@ this_testdata = read_testdata(TESTDATA_FILE)
 @pytest.mark.skip(reason="TOO MANY DIFFERENCES: Error message here are more specific (IMHO)")
 @pytest.mark.parametrize("expression, error", this_testdata)
 def test_errors_with_datafile(expression, error):
-    if "\\" in expression:
-        pytest.skip("BACKSLASH-ESCAPING: Not supported yet")
-
     with pytest.raises(TagExpressionError) as exc_info:
         _ = TagExpressionParser().parse(expression)
 

--- a/python/tests/data/test_evaluations.py
+++ b/python/tests/data/test_evaluations.py
@@ -51,9 +51,6 @@ this_testdata = read_testdata(TESTDATA_FILE)
 
 @pytest.mark.parametrize("expression, tests", this_testdata)
 def test_parsing_with_datafile(expression, tests):
-    if "\\" in expression:
-        pytest.skip("BACKSLASH-ESCAPING: Not supported yet")
-
     print("expression := {0}".format(expression))
     tag_expression = TagExpressionParser().parse(expression)
     for test_data in tests:

--- a/python/tests/data/test_parsing.py
+++ b/python/tests/data/test_parsing.py
@@ -39,9 +39,6 @@ this_testdata = read_testdata(TESTDATA_FILE)
 
 @pytest.mark.parametrize("expression, formatted", this_testdata)
 def test_parsing_with_datafile(expression, formatted):
-    if "\\" in expression:
-        pytest.skip("BACKSLASH-ESCAPING: Not supported yet")
-
     tag_expression = TagExpressionParser().parse(expression)
     actual_text = str(tag_expression)
     assert actual_text == formatted

--- a/python/tests/unit/test_parser.py
+++ b/python/tests/unit/test_parser.py
@@ -123,6 +123,12 @@ class TestTagExpressionParser(object):
         print(exc_text)
         assert error_message in exc_text
 
+    @staticmethod
+    def assert_tokenize_expression_equals_token_list(text, expected):
+        parser = TagExpressionParser()
+        tokens = parser.tokenize(text)
+        assert expected == tokens
+
 
     # -- TESTS FOR: TagExpressionParser.parse()
     correct_test_data = [
@@ -171,6 +177,18 @@ class TestTagExpressionParser(object):
     ])
     def test_parse__with_not_not(self, text, expected):
         self.assert_parse_expression_equals_expression_string(text, expected)
+
+    @pytest.mark.parametrize("text, expected", [
+        (r"@a\(1\) and @b\(2\)", "( @a\\(1\\) and @b\\(2\\) )"),
+    ])
+    def test_parse__with_escape(self, text, expected):
+        self.assert_parse_expression_equals_expression_string(text, expected)
+
+    @pytest.mark.parametrize("text, expected", [
+        (r"@a\(1\) and @b\(2\)", "And(Literal('@a(1)'), Literal('@b(2)'))"),
+    ])
+    def test_parse__with_escape_repr(self, text, expected):
+        self.assert_parse_expression_equals_expression_repr(text, expected)
 
 
     # -- BAD CASES:
@@ -270,4 +288,19 @@ class TestTagExpressionParser(object):
         token = TagExpressionParser.select_token(text)
         assert token is expected
 
+
+    @pytest.mark.parametrize("text, expected", [
+        ("not (a and b) or c", ["not", "(", "a", "and", "b", ")", "or", "c"])
+    ])
+    def test_tokenize__without_escape(self, text, expected):
+        """Ensures that tokenize works when there are no escapes."""
+        self.assert_tokenize_expression_equals_token_list(text, expected)
+
+    @pytest.mark.parametrize("text, expected", [
+        (r"@a\(1\) and @b\(2\)", ["@a(1)", "and", "@b(2)"]),
+        (r"@a\ 1 and @b\ 2", ["@a 1", "and", "@b 2"])
+    ])
+    def test_tokenize__with_escape(self, text, expected):
+        """Ensures that tokenize works when there are no escapes."""
+        self.assert_tokenize_expression_equals_token_list(text, expected)
 


### PR DESCRIPTION
### 🤔 What's changed?

The feature of escaping is now also supported in Python.

### ⚡️ What's your motivation? 

Consistency between implementations

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)
- :zap: New feature (non-breaking change which adds new behaviour)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
