### PR TITLE
Standardise Python to language agnostic errors

### DIFF
--- a/python/tests/data/test_errors.py
+++ b/python/tests/data/test_errors.py
@@ -39,7 +39,6 @@ def read_testdata(data_filename):
 # -----------------------------------------------------------------------------
 this_testdata = read_testdata(TESTDATA_FILE)
 
-@pytest.mark.skip(reason="TOO MANY DIFFERENCES: Error message here are more specific (IMHO)")
 @pytest.mark.parametrize("expression, error", this_testdata)
 def test_errors_with_datafile(expression, error):
     with pytest.raises(TagExpressionError) as exc_info:


### PR DESCRIPTION
### 🤔 What's changed?

- Consolidate Python error messages to standardised format

### ⚡️ What's your motivation? 

- Closes #18

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

- Whether appropriate to align these errors with other implementations - given the reason listed against the error messages: `"TOO MANY DIFFERENCES: Error message here are more specific (IMHO)"`
- Guidance/direction - what is appropriate way to resolve - interested in all perspectives

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.